### PR TITLE
chore: add assets path check

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Modify flake.nix
   services.dae = {
       enable = true;
       disableTxChecksumIpGeneric = false;
-      configFilePath = "/etc/dae/config.dae";
+      configFile = "/etc/dae/config.dae";
       assets = with pkgs; [ v2ray-geoip v2ray-domain-list-community ];
       openFirewall = {
         enable = true;


### PR DESCRIPTION
## Summary

Add assets path check to avoid user-set asset packages does not contain the preset path.