### PR TITLE
chore: avoid module conflict

### DIFF
--- a/dae/module.nix
+++ b/dae/module.nix
@@ -79,6 +79,8 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    # disables Nixpkgs dae module to avoid conflicts
+    disabledModules = [ "services/networking/dae.nix" ];
     environment.systemPackages = [ cfg.package ];
     systemd.packages = [ cfg.package ];
     networking = lib.mkIf cfg.openFirewall.enable {

--- a/flake.lock
+++ b/flake.lock
@@ -92,11 +92,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1692264070,
-        "narHash": "sha256-WepAkIL2UcHOj7JJiaFS/vxrA9lklQHv8p+xGL+7oQ0=",
+        "lastModified": 1692913444,
+        "narHash": "sha256-1SvMQm2DwofNxXVtNWWtIcTh7GctEVrS/Xel/mdc6iY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "42c25608aa2ad4e5d3716d8d63c606063513ba33",
+        "rev": "18324978d632ffc55ef1d928e81630c620f4f447",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Since nixpkgs has a dae module https://github.com/NixOS/nixpkgs/pull/247358

This pr will disable it for flake nixosModule user to avoid module conflict.

ref: https://github.com/hyprwm/Hyprland/blob/ae69b9a2fa559d869f4e9c61ddf24e152d97df2f/nix/module.nix#L19