### PR TITLE
ci/fix(sync-changes-to-{child,release}-branches): fix cherrypick-branch naming

### DIFF
--- a/.github/workflows/sync-changes-to-child-branches.yml
+++ b/.github/workflows/sync-changes-to-child-branches.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Cherry pick changes into target branch
         # https://github.com/carloscastrojumo/github-cherry-pick-action
-        uses: carloscastrojumo/github-cherry-pick-action@v1.0.1
+        uses: carloscastrojumo/github-cherry-pick-action@main
         with:
           branch: ${{ matrix.branch }}
           labels: |

--- a/.github/workflows/sync-changes-to-release-branch.yml
+++ b/.github/workflows/sync-changes-to-release-branch.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Cherry pick changes into target branch
         # https://github.com/carloscastrojumo/github-cherry-pick-action
-        uses: carloscastrojumo/github-cherry-pick-action@v1.0.1
+        uses: carloscastrojumo/github-cherry-pick-action@main
         with:
           branch: ${{ matrix.branch }}
           labels: |


### PR DESCRIPTION
## Summary

As the title suggests.