### PR TITLE
ci(automerge-sync-pr): only trigger the workflow based off target branches

### DIFF
--- a/.github/workflows/automerge-sync-pr.yml
+++ b/.github/workflows/automerge-sync-pr.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types:
       - opened
+    branches:
+      - unstable
+      - experiment
 
 jobs:
   sync-changes:


### PR DESCRIPTION
## Summary

As the title suggests.