### PR TITLE
chore(dae): pin ref to v0.8.0

### DIFF
--- a/dae/metadata.json
+++ b/dae/metadata.json
@@ -1,6 +1,6 @@
 {
-  "version": "v0.7.4",
-  "rev": "v0.7.4",
-  "hash": "sha256-bJ/a/SCNCutQDbmxPp36SYY7qhji2XRv6awp7buZVc0=",
-  "vendorHash": "sha256-CVQTBJDwu7AYz6q0MnFPMINRShcnS1JOGqH+Ro4lIRo="
+  "version": "v0.8.0",
+  "rev": "v0.8.0",
+  "hash": "sha256-Vdh5acE5i/bJ8VXOm+9OqZQbxvqv4TS/t0DDfBs/K5g=",
+  "vendorHash": "sha256-0Q+1cXUu4EH4qkGlK6BIpv4dCdtSKjb1RbLi5Xfjcew="
 }


### PR DESCRIPTION
## Summary

As the title suggests.

## Results

```console
⯁ flake.nix git:(pin-dae-v0.8.0) ✗ ❯❯❯ just build dae
warning: Git tree '/home/kev/Workspace/work/flake.nix' is dirty
⯁ flake.nix git:(pin-dae-v0.8.0) ✗ ❯❯❯ just version dae
dae version v0.8.0
go runtime go1.22.5 linux/amd64
Copyright (c) 2022-2024 @daeuniverse
License GNU AGPLv3 <https://github.com/daeuniverse/dae/blob/main/LICENSE>
⯁ flake.nix git:(pin-dae-v0.8.0) ✗ ❯❯❯
```