### PR TITLE
feat: refactor auto update

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@
 
       /* default options
 
-      package = inputs.daeuniverse.packages.x86_64-linux.dae;
+      package = inputs.daeuniverse.packages.x86_64-linux.dae; or dae-unstable etc.
       disableTxChecksumIpGeneric = false;
       configFile = "/etc/dae/config.dae";
       assets = with pkgs; [ v2ray-geoip v2ray-domain-list-community ];
@@ -82,57 +82,75 @@
 
 ## Globally install packages
 
+
+This flake contains serval different revision of packages:
+
++ dae (alias of dae-release)
++ dae-release (current latest release version)
++ dae-unstable (keep sync with dae `main` branch)
++ dae-experiment (specific pull request for untested features)
+
+See details with `nix flake show github:daeuniverse/flake.nix`
+
 ```nix
 # nixos configuration module
 {
   environment.systemPackages =
     with inputs.daeuniverse.packages.x86_64-linux;
-      [ dae daed ];
+      [ dae daed ]; # or dae-unstable dae-experient
 }
 ```
 
-## Nightly build
+## Package Options
 
-If you would like to get a taste of new features and do not want to wait for new releases, you may use the `nightly` (`unstable` branch) flake. The `nightly` flake is always _**up-to-date**_ with the upstream `dae` and `daed` (sync with the `main` branch) projects. Most of the time, newly proposed changes will be included in PRs, will be fully tested, and will be exported as cross-platform executable binaries in builds (GitHub Action Workflow Build). If you would like to test out any unpublished changes, feel free to use the `experiment` branch which is pinned to a specific commit in a feature branch from the upstream repositories.
+- **Nightly Build**: Use the `dae-unstable` package for early access to new features, always synced with the latest updates. For testing specific, unpublished changes, try `dae-experiment`, pinned to feature branch commits.
+
+- **Release Build**: Use the `dae` or `dae-release` package for stable, production-ready version. History versions are available with tags (e.g. `refs/tags/dae-v0.8.0`).
 
 > [!WARNING]
 > Note that newly introduced features can sometimes be buggy; use at your own risk. However, we still highly encourage you to check out our latest builds as it may help us further analyze features stability and resolve potential bugs accordingly.
 
-Adopt nightly flake
+## Script Usage
 
-```nix
-# flake.nix
-{
-  # unstable
-  inputs.daeuniverse.url = "github:daeuniverse/flake.nix/unstable";
-  # OR
-  # experiment
-  inputs.daeuniverse.url = "github:daeuniverse/flake.nix/experiment";
-  # ...
-}
+The `main.nu` script on top-level of this repo is able to help you update the package. See help message with `./main.nu`.
+
+The cmd args looks like:
+```
+# usage
+commands: [sync] <PROJECT> <VERSIONS...> --rev <REVISION>
 ```
 
-## Release build
+About **adding a new version**, if the `VERSIONS` you provided doesn't match any of `["release" "unstable"]`, it will:
 
-If you prefer to use a more stable version of our software, you can use the `release` branch. This branch is designated for our official releases. We create release tags based on this branch to ensure stability and reliability.
++ Check the `--rev` arg and read its value
++ Run `nix-prefetch-git` to get its info
++ Adding a new record to `metadata.json`
++ Update the vendorHash.
 
-Whenever there is a new release from the upstream projects (`dae` and `daed`), we will also create a corresponding release tag in our repository, such as `dae-v0.7.0`. These tags represent the stable versions of our software, thoroughly tested and ready for production use.
+The `--rev` args could pass in with:
 
-Adopt release flake
++ revision hash
++ refs/heads/
++ refs/tags/v0.0.0
 
-```nix
-# flake.nix
-{
-  # latest release
-  inputs.daeuniverse.url = "github:daeuniverse/flake.nix/release";
-  # OR
-  # specific tag
-  inputs.daeuniverse.url = "github:daeuniverse/flake.nix?tag=<tag>";
-  # ...
-}
+Workflow for updating release and unstable:
+
+```
+./main.nu sync dae release unstable # or leave the last 2 args empty
 ```
 
-This way, users can choose the `release` branch and tags for stable, `production-ready` versions.
+workflow for updating single version:
+
+```
+./main.nu sync dae release # or unstable
+```
+
+workflow for adding a new version:
+
+```
+./main.nu sync dae sth-new --rev 'rev_hash' or refs/heads/<branch> or refs/tags/v0.0.0
+# after this will produce a new package called dae-sth-new
+```
 
 ## Binary cache
 

--- a/dae/metadata.json
+++ b/dae/metadata.json
@@ -1,6 +1,0 @@
-{
-  "version": "v0.8.0",
-  "rev": "v0.8.0",
-  "hash": "sha256-Vdh5acE5i/bJ8VXOm+9OqZQbxvqv4TS/t0DDfBs/K5g=",
-  "vendorHash": "sha256-0Q+1cXUu4EH4qkGlK6BIpv4dCdtSKjb1RbLi5Xfjcew="
-}

--- a/dae/package.nix
+++ b/dae/package.nix
@@ -5,7 +5,7 @@
   buildGoModule,
 }:
 let
-  metadata = builtins.fromJSON (builtins.readFile ./metadata.json);
+  metadata = (builtins.fromJSON (builtins.readFile ../metadata.json)).dae.release;
 in
 buildGoModule rec {
   pname = "dae";
@@ -24,10 +24,11 @@ buildGoModule rec {
 
   hardeningDisable = [ "zerocallusedregs" ];
 
+  env.VERSION = version;
+
   buildPhase = ''
     make CFLAGS="-D__REMOVE_BPF_PRINTK -fno-stack-protector -Wno-unused-command-line-argument" \
     NOSTRIP=y \
-    VERSION=${version} \
     OUTPUT=$out/bin/dae
   '';
 

--- a/main.nu
+++ b/main.nu
@@ -1,7 +1,24 @@
 #!/usr/bin/env nu
 
 def main [] {
-  print -e "commands: [sync] PROJECT VERSION1 VERSION2...\n--rev 'refs/heads/v1.0.0' | rev_hash"
+  print -e "commands: [sync] <PROJECT> <VERSIONS...> --rev <REVISION>"
+  print -e $'(char newline)'
+  print -e "REVISION: Any sha1 or references"
+  print -e "          e.g. 'refs/tags/v1.0.0' | 'refs/heads/main' | rev_hash"
+  print -e $'(char newline)'
+  print -e "VERSIONS: List of versions to be updated."
+  print -e "          e.g. release unstable"
+  print -e $'(char newline)'
+  print -e "PROJECT:  Project to be update. Current only support dae."
+  print -e "          e.g. dae"
+  print -e $'(char newline)'
+  print -e 'example:'
+  print -e "  updating unstable"
+  print -e "          ./main.nu sync dae unstable"
+  print -e "  updating unstable and release"
+  print -e "          ./main.nu sync dae unstable release"
+  print -e "  adding a new version"
+  print -e "          ./main.nu sync dae sth-new --rev 'rev_hash'"
 }
 
 # ./main.nu sync dae release unstable

--- a/metadata.json
+++ b/metadata.json
@@ -11,12 +11,6 @@
       "rev": "d3ab0b25e705399d7e610d6f09453623674e20d3",
       "hash": "sha256-iUVTnFPeWQkFZBsxbnBe/lVO9FTqmQeSzDsgPa5ZqLY=",
       "vendorHash": "sha256-rGwVsDgcNGWppte0BXQF9p0pKbnjqeNBRn5oNxrxsjU="
-    },
-    "experiment": {
-      "version": "v0.7.0",
-      "rev": "v0.7.0",
-      "hash": "sha256-9iwrwQGpryGyEUVB2reodIxuEQHkXPA4P5IYKj18elI=",
-      "vendorHash": "sha256-AtYLxR7Fw3+IOSeuPXlq4vMsnS+7MMaFANZDg0yvCl8="
     }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,22 @@
+{
+  "dae": {
+    "release": {
+      "version": "v0.8.0",
+      "rev": "v0.8.0",
+      "hash": "sha256-Vdh5acE5i/bJ8VXOm+9OqZQbxvqv4TS/t0DDfBs/K5g=",
+      "vendorHash": "sha256-0Q+1cXUu4EH4qkGlK6BIpv4dCdtSKjb1RbLi5Xfjcew="
+    },
+    "unstable": {
+      "version": "unstable-2024-11-03.d3ab0b2",
+      "rev": "d3ab0b25e705399d7e610d6f09453623674e20d3",
+      "hash": "sha256-iUVTnFPeWQkFZBsxbnBe/lVO9FTqmQeSzDsgPa5ZqLY=",
+      "vendorHash": "sha256-rGwVsDgcNGWppte0BXQF9p0pKbnjqeNBRn5oNxrxsjU="
+    },
+    "experiment": {
+      "version": "v0.7.0",
+      "rev": "v0.7.0",
+      "hash": "sha256-9iwrwQGpryGyEUVB2reodIxuEQHkXPA4P5IYKj18elI=",
+      "vendorHash": "sha256-AtYLxR7Fw3+IOSeuPXlq4vMsnS+7MMaFANZDg0yvCl8="
+    }
+  }
+}


### PR DESCRIPTION
# Summary

Add package layout change. This change is backward compatible.

## Proposed features

After this change, we could get rid of syncing between different branches, reduce CI time cost. Users will be able to switch between versions without changing flake inputs.

Other branches are expected to be identical to the `main` for a while (with warning) and then deprecate.

## On main branch:
```patch
2a3,5
>     ├───dae-experiment: package 'dae-v0.7.0' - 'A Linux high-performa…'
>     ├───dae-release: package 'dae-v0.8.0' - 'A Linux high-performance…'
>     ├───dae-unstable: package 'dae-unstable-2024-11-03.d3ab0b2' - 'A …'
```
`dae` is now an alias of `dae-release`.


## Move `metadata.json`

To top-level and contains all revision info about dae.
Other package info could be added future.

```json5
{
  "dae": {
    "release": {
      "version": "v0.8.0",
      "rev": "v0.8.0",
      "hash": "sha256-Vdh5acE5i/bJ8VXOm+9OqZQbxvqv4TS/t0DDfBs/K5g=",
      "vendorHash": "sha256-0Q+1cXUu4EH4qkGlK6BIpv4dCdtSKjb1RbLi5Xfjcew="
    },
    "unstable": {
//...
    },
    "experiment": {
 //...
    }
  }
}
```

## Auto-update script

try with:

```
./main.nu sync
# also with extra args `unstable` `release` +
```

In nixpkgs, `buildGoModule` is during refactoring. The overriding in this repo is expected to be more elegant.

## Action items

as far as maintenance concerned, add relevant maintenance notes to highlight the following:
 
> if the revision you provided doesn't match any of `["release" "unstable"]`, it will: check the `--rev` args, read its value, run `nix-prefetch-git` and get relative info, adding a new record to `metadata.json`, then update the `vendorHash`

- [x] Completed