### PR TITLE
dae: configFile option more strict check

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ About **adding a new version**, if the `VERSION` you provided doesn't match any 
 The `--rev` args could pass in with any sha1 or references:
 
 + revision sha1 hash
-+ refs/heads/<branch>
++ refs/heads/\<branch>
 + refs/tags/v0.0.0
 
 Workflow for updating release and unstable:

--- a/dae/module.nix
+++ b/dae/module.nix
@@ -95,16 +95,18 @@ in
           let
             inherit (types) nullOr addCheck str;
             isAbsolutePathString = x: lib.substring 0 1 x == "/";
+            isNotInStore = x: !lib.hasPrefix builtins.storeDir x;
+            combineTopic = x: isAbsolutePathString x && isNotInStore x;
           in
-          (nullOr (addCheck str isAbsolutePathString))
+          (nullOr (addCheck str combineTopic))
           // {
-            description = "${types.str.description} (with check: is absolute path string)";
+            description = "${types.str.description} (with check: should be absolute path **string** which not a store path)";
           };
         default = null;
         example = ''"/path/to/your/config.dae"'';
         description = ''
-          The absolute path string of dae config file, end with `.dae`.
-          Will fallback to `"/etc/dae/config.dae"` if this is not set.
+          The absolute path string of dae config file which not in nix store,
+          end with `.dae`. Will fallback to `"/etc/dae/config.dae"` if this is not set.
         '';
       };
 


### PR DESCRIPTION
Since people still bypass the existing check in weird way like:

![image](https://github.com/user-attachments/assets/26fcff43-4c0b-4917-a34d-e68fe36df44c)

Previous related: #106 #105
