### PR TITLE
fix daed pnpmDeps hash

### DIFF
--- a/daed/package.nix
+++ b/daed/package.nix
@@ -25,7 +25,7 @@ let
     pnpmDeps = pnpm.fetchDeps {
       inherit pname version src;
       fetcherVersion = 2;
-      hash = "sha256-N85njUxA4iQJCItCG40uroEuCAQiazHm31nrnOiIKZY=";
+      hash = "sha256-G5HJQzxV0CFyFybauet6UpKmwQCvtz7Pcv4VCdFPBnk=";
     };
 
     nativeBuildInputs = [


### PR DESCRIPTION
```
error: hash mismatch in fixed-output derivation '/nix/store/w04h8xb7gb0bhzd19ya5hpwpx6cbq2rk-daed-pnpm-deps.drv':
         specified: sha256-N85njUxA4iQJCItCG40uroEuCAQiazHm31nrnOiIKZY=
            got:    sha256-G5HJQzxV0CFyFybauet6UpKmwQCvtz7Pcv4VCdFPBnk=
```