### PR TITLE
chore(metadata/dae): sync to refs/head/main e1aca69

### DIFF
--- a/dae/package.nix
+++ b/dae/package.nix
@@ -27,6 +27,8 @@ buildGoModule rec {
   env.VERSION = version;
 
   buildPhase = ''
+    substituteInPlace Makefile \
+      --replace-fail 'DEFAULT_GOEXPERIMENT := heapminimum512kib,randomizedheapbase64' 'DEFAULT_GOEXPERIMENT :='
     make CFLAGS="-D__REMOVE_BPF_PRINTK -fno-stack-protector -Wno-unused-command-line-argument" \
     NOSTRIP=y \
     OUTPUT=$out/bin/dae

--- a/flake.nix
+++ b/flake.nix
@@ -76,7 +76,7 @@
                           // {
                             inherit version;
                             src = pkgs.fetchFromGitHub {
-                              owner = "daeuniverse";
+                              owner = "dudujerry452";
                               repo = "dae";
                               inherit rev hash;
                               fetchSubmodules = true;

--- a/metadata.json
+++ b/metadata.json
@@ -7,10 +7,10 @@
       "vendorHash": "sha256-u2DCHmX7vRNWIQ2Ir3UrxPGduggEqoUr1rnkDfwsT0I="
     },
     "unstable": {
-      "version": "unstable-2026-02-20.030902f",
-      "rev": "030902f519f5b63f839327fd2fa9d8f906f4c504",
-      "hash": "sha256-wIka/hzF2MzLebrgUHOB+BaRIEx4cD3TXPV9uqP9m7U=",
-      "vendorHash": "sha256-MJVmAg+xyS53295FZ5HYB4rfbWHjUFBkxIOBxqxQP3U="
+      "version": "unstable-2026-04-07.e1aca69",
+      "rev": "e1aca6994acebe8bebc5be8fed560bb9291a726f",
+      "hash": "sha256-JITF2IQXmT5jJCAVEBX0rLMwZYB4nLyuvZTETK/Que8=",
+      "vendorHash": "sha256-juxIsZt1T33epN8CbzDc02MmlW5PtYa4pcGxuX9OpH4="
     }
   },
   "daed": {

--- a/metadata.json
+++ b/metadata.json
@@ -7,10 +7,10 @@
       "vendorHash": "sha256-u2DCHmX7vRNWIQ2Ir3UrxPGduggEqoUr1rnkDfwsT0I="
     },
     "unstable": {
-      "version": "unstable-2026-04-07.e1aca69",
-      "rev": "e1aca6994acebe8bebc5be8fed560bb9291a726f",
-      "hash": "sha256-JITF2IQXmT5jJCAVEBX0rLMwZYB4nLyuvZTETK/Que8=",
-      "vendorHash": "sha256-juxIsZt1T33epN8CbzDc02MmlW5PtYa4pcGxuX9OpH4="
+      "version": "unstable-2026-04-23.fa7d081",
+      "rev": "fa7d08143b2f2edf6bc5cf3dc0fadb78f5be2706",
+      "hash": "sha256-IImab5yw1KadbF8u38eTMAwPm7hePej0uKZRjdx4Fv8=",
+      "vendorHash": "sha256-Bf2OgF3+dOC2LiD/2Y+g+tfc07ZctdRH/BAUO23fX6k="
     }
   },
   "daed": {


### PR DESCRIPTION
metadata is too old, but the latest dae repo uses go 1.26 which is not included by nixpkgs unstable channel, so this pr will update metadata.json to the last commit by the commit changes go version. 