### PR TITLE
Fix string interpolation in pkgsText

### DIFF
--- a/dae/module.nix
+++ b/dae/module.nix
@@ -37,7 +37,7 @@ in
       enable = mkEnableOption "dae, a Linux high-performance transparent proxy solution based on eBPF";
 
       package = mkPackageOption (withSystem system ({ config, ... }: config.packages)) "dae" {
-        pkgsText = "flake.packages.$\{pkgs.system}.dae";
+        pkgsText = "flake.packages.\${pkgs.system}.dae";
       };
 
       assets = mkOption {

--- a/daed/module.nix
+++ b/daed/module.nix
@@ -28,7 +28,7 @@ in
       enable = mkEnableOption "A modern dashboard for dae";
 
       package = mkPackageOption (withSystem system ({ config, ... }: config.packages)) "daed" {
-        pkgsText = "flake.packages.$\{pkgs.system}.daed";
+        pkgsText = "flake.packages.\${pkgs.system}.daed";
       };
 
       configDir = mkOption {


### PR DESCRIPTION
Fix warning in evaluation:

```
warning: \{ is an ill-defined escape. You can drop the \ and simply write { instead. If you meant to escape an interpolation, write \${ instead. Use --extra-deprecated-features broken-string-escape to silence this warning.
         at /nix/store/y57kaz4mpm9v9wp31y0z6rjv2d5bkh05-source/daed/module.nix:31:38:
             30|       package = mkPackageOption (withSystem system ({ config, ... }: config.packages)) "daed" {
             31|         pkgsText = "flake.packages.$\{pkgs.system}.daed";
               |                                      ^
             32|       };
```